### PR TITLE
[feat] Modify AutoTradingSystem tests to use Interface instead of mockDriver

### DIFF
--- a/TradingSystem/auto_trading_system.cpp
+++ b/TradingSystem/auto_trading_system.cpp
@@ -5,50 +5,50 @@
 #include <thread>
 
 bool AutoTradingSystem::buyNiceTiming(std::string& stockCode,
-                                      int availableFunds) {
-  int price = checkPriceIncrease(stockCode);
-  if (price == -1) {
-    return false;
-  }
-  std::cout << "Bought " << availableFunds / price << " shares at " << price
-            << " dollars automatically!" << std::endl;
-  return true;
+	int availableFunds) {
+	int price = checkPriceIncrease(stockCode);
+	if (price == -1) {
+		return false;
+	}
+	std::cout << "Bought " << availableFunds / price << " shares at " << price
+		<< " dollars automatically!" << std::endl;
+	return true;
 }
 
 bool AutoTradingSystem::sellNiceTiming(std::string& stockCode, int numShares) {
-  int price = checkPriceDecrease(stockCode);
-  if (price == -1) {
-    return false;
-  }
-  std::cout << "Sold " << numShares << " shares at " << price
-            << " dollars automatically!" << std::endl;
-  return true;
+	int price = checkPriceDecrease(stockCode);
+	if (price == -1) {
+		return false;
+	}
+	std::cout << "Sold " << numShares << " shares at " << price
+		<< " dollars automatically!" << std::endl;
+	return true;
 }
 
 int AutoTradingSystem::checkPriceIncrease(std::string& stockCode) {
-  int current = 0;
-  int prev = 0;
-  for (int i = 0; i < 3; i++) {
-    current = driverInterface.getCurrentPrice(stockCode);
-    if (current < prev) {
-      return -1;
-    }
-    prev = current;
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
-  }
-  return current;
+	int current = 0;
+	int prev = 0;
+	for (int i = 0; i < 3; i++) {
+		current = driverInterface.getCurrentPrice(stockCode);
+		if (current < prev) {
+			return -1;
+		}
+		prev = current;
+		std::this_thread::sleep_for(std::chrono::milliseconds(200));
+	}
+	return current;
 }
 
 int AutoTradingSystem::checkPriceDecrease(std::string& stockCode) {
-  int prev = -1;
-  int current = -1;
-  for (int i = 0; i < 3; i++) {
-    current = driverInterface.getCurrentPrice(stockCode);
-    if (prev != -1 && current > prev) {
-      return -1;
-    }
-    prev = current;
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
-  }
-  return current;
+	int prev = -1;
+	int current = -1;
+	for (int i = 0; i < 3; i++) {
+		current = driverInterface.getCurrentPrice(stockCode);
+		if (prev != -1 && current > prev) {
+			return -1;
+		}
+		prev = current;
+		std::this_thread::sleep_for(std::chrono::milliseconds(200));
+	}
+	return current;
 }

--- a/TradingSystem/auto_trading_system.h
+++ b/TradingSystem/auto_trading_system.h
@@ -4,15 +4,15 @@
 #include "stock_broker_driver.h"
 
 class AutoTradingSystem {
- public:
-  AutoTradingSystem(StockBrokerDriver& driverInterface)
-      : driverInterface{driverInterface} {};
+public:
+	AutoTradingSystem(StockBrokerDriver& driverInterface)
+		: driverInterface{ driverInterface } {};
 
-  bool buyNiceTiming(std::string& stockCode, int availableFunds);
-  bool sellNiceTiming(std::string& stockCode, int numShares);
+	bool buyNiceTiming(std::string& stockCode, int availableFunds);
+	bool sellNiceTiming(std::string& stockCode, int numShares);
 
- private:
-  StockBrokerDriver& driverInterface;
-  int checkPriceIncrease(std::string& stockCode);
-  int checkPriceDecrease(std::string& stockCode);
+private:
+	StockBrokerDriver& driverInterface;
+	int checkPriceIncrease(std::string& stockCode);
+	int checkPriceDecrease(std::string& stockCode);
 };

--- a/TradingSystem/main.cpp
+++ b/TradingSystem/main.cpp
@@ -10,227 +10,227 @@
 using namespace testing;
 
 class TradingFixture : public Test {
- public:
-  MockStockAPI mockStockAPI;
+public:
+	MockStockAPI mockStockAPI;
 
-  KiwerDriver kiwerDriver{&kiwerAPI};
-  NemoDriver nemoDriver{&nemoAPI};
-  MockDriver mockDriver{&mockStockAPI};
+	KiwerDriver kiwerDriver{ &kiwerAPI };
+	NemoDriver nemoDriver{ &nemoAPI };
+	MockDriver mockDriver{ &mockStockAPI };
 
-  AutoTradingSystem* autoTradingSystem;
-  StockBrokerDriver* stockBrokerDriver;
+	AutoTradingSystem* autoTradingSystem;
+	StockBrokerDriver* stockBrokerDriver;
 
-  std::string ID = "1234";
-  std::string SUCCESS_PASSWORD = "1234";
-  std::string STOCK_CODE = "code";
-  int money = 100;
+	std::string ID = "1234";
+	std::string SUCCESS_PASSWORD = "1234";
+	std::string STOCK_CODE = "code";
+	int money = 100;
 
- private:
-  KiwerAPI kiwerAPI;
-  NemoAPI nemoAPI;
-  void SetUp() override {
-    // nothing;
-  }
+private:
+	KiwerAPI kiwerAPI;
+	NemoAPI nemoAPI;
+	void SetUp() override {
+		// nothing;
+	}
 };
 
 ///////////////////////////////////////////
 // Mock test
 //////////////////////////////////////////
 TEST_F(TradingFixture, TEST_LOGIN) {
-  stockBrokerDriver = &mockDriver;
+	stockBrokerDriver = &mockDriver;
 
-  EXPECT_CALL(mockStockAPI, login(_, _)).Times(1).WillOnce(Return(true));
+	EXPECT_CALL(mockStockAPI, login(_, _)).Times(1).WillOnce(Return(true));
 
-  stockBrokerDriver->login(ID, SUCCESS_PASSWORD);
+	stockBrokerDriver->login(ID, SUCCESS_PASSWORD);
 }
 
 TEST_F(TradingFixture, TEST_BUY) {
-  stockBrokerDriver = &mockDriver;
+	stockBrokerDriver = &mockDriver;
 
-  int quantity = 10;
-  int price = 100;
+	int quantity = 10;
+	int price = 100;
 
-  EXPECT_CALL(mockStockAPI, buy(STOCK_CODE, quantity, price))
-      .Times(1)
-      .WillOnce(Return(true));
+	EXPECT_CALL(mockStockAPI, buy(STOCK_CODE, quantity, price))
+		.Times(1)
+		.WillOnce(Return(true));
 
-  stockBrokerDriver->buy(STOCK_CODE, quantity, price);
+	stockBrokerDriver->buy(STOCK_CODE, quantity, price);
 }
 
 TEST_F(TradingFixture, TEST_SELL) {
-  stockBrokerDriver = &mockDriver;
+	stockBrokerDriver = &mockDriver;
 
-  int quantity = 10;
-  int price = 100;
+	int quantity = 10;
+	int price = 100;
 
-  EXPECT_CALL(mockStockAPI, sell(STOCK_CODE, quantity, price))
-      .Times(1)
-      .WillOnce(Return(true));
+	EXPECT_CALL(mockStockAPI, sell(STOCK_CODE, quantity, price))
+		.Times(1)
+		.WillOnce(Return(true));
 
-  stockBrokerDriver->sell(STOCK_CODE, quantity, price);
+	stockBrokerDriver->sell(STOCK_CODE, quantity, price);
 }
 
 TEST_F(TradingFixture, TEST_GET_PRICE) {
-  stockBrokerDriver = &mockDriver;
-  int expectedPrice = 100;
+	stockBrokerDriver = &mockDriver;
+	int expectedPrice = 100;
 
-  EXPECT_CALL(mockStockAPI, getCurrentPrice(STOCK_CODE))
-      .Times(1)
-      .WillOnce(Return(expectedPrice));
+	EXPECT_CALL(mockStockAPI, getCurrentPrice(STOCK_CODE))
+		.Times(1)
+		.WillOnce(Return(expectedPrice));
 
-  int actualPrice = stockBrokerDriver->getCurrentPrice(STOCK_CODE);
+	int actualPrice = stockBrokerDriver->getCurrentPrice(STOCK_CODE);
 
-  EXPECT_EQ(expectedPrice, actualPrice);
+	EXPECT_EQ(expectedPrice, actualPrice);
 }
 
 ///////////////////////////////////////////
 // Auto Trading system test
 //////////////////////////////////////////
 TEST_F(TradingFixture, TEST_buyNiceTiming__Buy_success) {
-  stockBrokerDriver = &mockDriver;
-  autoTradingSystem = new AutoTradingSystem(*stockBrokerDriver);
-  std::vector<int> price = {12, 20, 30};
+	stockBrokerDriver = &mockDriver;
+	autoTradingSystem = new AutoTradingSystem(*stockBrokerDriver);
+	std::vector<int> price = { 12, 20, 30 };
 
-  EXPECT_CALL(mockStockAPI, getCurrentPrice(STOCK_CODE))
-      .WillOnce(Return(price[0]))
-      .WillOnce(Return(price[1]))
-      .WillOnce(Return(price[2]))
-      .WillRepeatedly(Return(price[2]));
+	EXPECT_CALL(mockStockAPI, getCurrentPrice(STOCK_CODE))
+		.WillOnce(Return(price[0]))
+		.WillOnce(Return(price[1]))
+		.WillOnce(Return(price[2]))
+		.WillRepeatedly(Return(price[2]));
 
-  bool success = autoTradingSystem->buyNiceTiming(STOCK_CODE, money);
-  EXPECT_EQ(true, success);
+	bool success = autoTradingSystem->buyNiceTiming(STOCK_CODE, money);
+	EXPECT_EQ(true, success);
 }
 
 TEST_F(TradingFixture, TEST_buyNiceTiming__Buy_fail) {
-  stockBrokerDriver = &mockDriver;
-  autoTradingSystem = new AutoTradingSystem(*stockBrokerDriver);
-  std::vector<int> price = {40, 20, 30};
+	stockBrokerDriver = &mockDriver;
+	autoTradingSystem = new AutoTradingSystem(*stockBrokerDriver);
+	std::vector<int> price = { 40, 20, 30 };
 
-  EXPECT_CALL(mockStockAPI, getCurrentPrice(STOCK_CODE))
-      .WillOnce(Return(price[0]))
-      .WillOnce(Return(price[1]));
+	EXPECT_CALL(mockStockAPI, getCurrentPrice(STOCK_CODE))
+		.WillOnce(Return(price[0]))
+		.WillOnce(Return(price[1]));
 
-  bool success = autoTradingSystem->buyNiceTiming(STOCK_CODE, money);
-  EXPECT_EQ(false, success);
+	bool success = autoTradingSystem->buyNiceTiming(STOCK_CODE, money);
+	EXPECT_EQ(false, success);
 }
 
 TEST_F(TradingFixture, TEST_sellNiceTiming__Sell_success) {
-  stockBrokerDriver = &mockDriver;
-  autoTradingSystem = new AutoTradingSystem(*stockBrokerDriver);
-  std::vector<int> price = {30, 20, 12};
+	stockBrokerDriver = &mockDriver;
+	autoTradingSystem = new AutoTradingSystem(*stockBrokerDriver);
+	std::vector<int> price = { 30, 20, 12 };
 
-  EXPECT_CALL(mockStockAPI, getCurrentPrice(_))
-      .WillOnce(Return(price[0]))
-      .WillOnce(Return(price[1]))
-      .WillOnce(Return(price[2]))
-      .WillRepeatedly(Return(price[2]));
+	EXPECT_CALL(mockStockAPI, getCurrentPrice(_))
+		.WillOnce(Return(price[0]))
+		.WillOnce(Return(price[1]))
+		.WillOnce(Return(price[2]))
+		.WillRepeatedly(Return(price[2]));
 
-  int cellCount = 3;
-  bool success = autoTradingSystem->sellNiceTiming(STOCK_CODE, cellCount);
+	int cellCount = 3;
+	bool success = autoTradingSystem->sellNiceTiming(STOCK_CODE, cellCount);
 
-  EXPECT_EQ(true, success);
+	EXPECT_EQ(true, success);
 }
 
 TEST_F(TradingFixture, TEST_sellNiceTiming__Sell_fail) {
-  stockBrokerDriver = &mockDriver;
-  autoTradingSystem = new AutoTradingSystem(*stockBrokerDriver);
-  std::vector<int> price = {40, 20, 30};
+	stockBrokerDriver = &mockDriver;
+	autoTradingSystem = new AutoTradingSystem(*stockBrokerDriver);
+	std::vector<int> price = { 40, 20, 30 };
 
-  EXPECT_CALL(mockStockAPI, getCurrentPrice(_))
-      .WillOnce(Return(price[0]))
-      .WillOnce(Return(price[1]))
-      .WillOnce(Return(price[2]))
-      .WillRepeatedly(Return(price[2]));
+	EXPECT_CALL(mockStockAPI, getCurrentPrice(_))
+		.WillOnce(Return(price[0]))
+		.WillOnce(Return(price[1]))
+		.WillOnce(Return(price[2]))
+		.WillRepeatedly(Return(price[2]));
 
-  int cellCount = 3;
-  bool success = autoTradingSystem->sellNiceTiming(STOCK_CODE, price[2]);
+	int cellCount = 3;
+	bool success = autoTradingSystem->sellNiceTiming(STOCK_CODE, price[2]);
 
-  EXPECT_EQ(false, success);
+	EXPECT_EQ(false, success);
 }
 
 ///////////////////////////////////////////
 // kiwerAPI test
 //////////////////////////////////////////
 TEST_F(TradingFixture, kiwerAPI_LOGIN) {
-  stockBrokerDriver = &kiwerDriver;
-  // EXPECT_CALL(kiwerAPI, login(_, _))
-  //	.Times(1);
+	stockBrokerDriver = &kiwerDriver;
+	// EXPECT_CALL(kiwerAPI, login(_, _))
+	//	.Times(1);
 
-  stockBrokerDriver->login(ID, SUCCESS_PASSWORD);
+	stockBrokerDriver->login(ID, SUCCESS_PASSWORD);
 }
 
 TEST_F(TradingFixture, kiwerAPI_BUY) {
-  stockBrokerDriver = &kiwerDriver;
-  int price = 100;
-  int num = 10;
+	stockBrokerDriver = &kiwerDriver;
+	int price = 100;
+	int num = 10;
 
-  // EXPECT_CALL(kiwerAPI, buy(_, _, _))
-  //	.Times(1);
+	// EXPECT_CALL(kiwerAPI, buy(_, _, _))
+	//	.Times(1);
 
-  stockBrokerDriver->buy(STOCK_CODE, price, num);
+	stockBrokerDriver->buy(STOCK_CODE, price, num);
 }
 
 TEST_F(TradingFixture, kiwerAPI_SELL) {
-  stockBrokerDriver = &kiwerDriver;
-  int price = 100;
-  int num = 10;
+	stockBrokerDriver = &kiwerDriver;
+	int price = 100;
+	int num = 10;
 
-  // EXPECT_CALL(kiwerAPI, sell(_, _, _))
-  //	.Times(1);
+	// EXPECT_CALL(kiwerAPI, sell(_, _, _))
+	//	.Times(1);
 
-  stockBrokerDriver->sell(STOCK_CODE, price, num);
+	stockBrokerDriver->sell(STOCK_CODE, price, num);
 }
 
 TEST_F(TradingFixture, kiwerAPI_GET_PRICE) {
-  stockBrokerDriver = &kiwerDriver;
-  int except = 100;
-  int actual = stockBrokerDriver->getCurrentPrice(STOCK_CODE);
+	stockBrokerDriver = &kiwerDriver;
+	int except = 100;
+	int actual = stockBrokerDriver->getCurrentPrice(STOCK_CODE);
 
-  // EXPECT_EQ(except, actual);
+	// EXPECT_EQ(except, actual);
 }
 
 ///////////////////////////////////////////
 // NemoAPI test
 //////////////////////////////////////////
 TEST_F(TradingFixture, NemoAPI_LOGIN) {
-  stockBrokerDriver = &nemoDriver;
-  // EXPECT_CALL(kiwerAPI, login(_, _))
-  //	.Times(1);
+	stockBrokerDriver = &nemoDriver;
+	// EXPECT_CALL(kiwerAPI, login(_, _))
+	//	.Times(1);
 
-  stockBrokerDriver->login(ID, SUCCESS_PASSWORD);
+	stockBrokerDriver->login(ID, SUCCESS_PASSWORD);
 }
 
 TEST_F(TradingFixture, NemoAPI_BUY) {
-  stockBrokerDriver = &nemoDriver;
-  int price = 100;
-  int num = 10;
+	stockBrokerDriver = &nemoDriver;
+	int price = 100;
+	int num = 10;
 
-  // EXPECT_CALL(kiwerAPI, buy(_, _, _))
-  //	.Times(1);
+	// EXPECT_CALL(kiwerAPI, buy(_, _, _))
+	//	.Times(1);
 
-  stockBrokerDriver->buy(STOCK_CODE, price, num);
+	stockBrokerDriver->buy(STOCK_CODE, price, num);
 }
 
 TEST_F(TradingFixture, NemoAPI_SELL) {
-  stockBrokerDriver = &nemoDriver;
-  int price = 100;
-  int num = 10;
+	stockBrokerDriver = &nemoDriver;
+	int price = 100;
+	int num = 10;
 
-  // EXPECT_CALL(kiwerAPI, sell(_, _, _))
-  //	.Times(1);
+	// EXPECT_CALL(kiwerAPI, sell(_, _, _))
+	//	.Times(1);
 
-  stockBrokerDriver->sell(STOCK_CODE, price, num);
+	stockBrokerDriver->sell(STOCK_CODE, price, num);
 }
 
 TEST_F(TradingFixture, NemoAPI_GET_PRICE) {
-  stockBrokerDriver = &nemoDriver;
-  int except = 100;
-  int actual = stockBrokerDriver->getCurrentPrice(STOCK_CODE);
+	stockBrokerDriver = &nemoDriver;
+	int except = 100;
+	int actual = stockBrokerDriver->getCurrentPrice(STOCK_CODE);
 
-  // EXPECT_EQ(except, actual);
+	// EXPECT_EQ(except, actual);
 }
 
 int main() {
-  ::testing::InitGoogleMock();
-  return RUN_ALL_TESTS();
+	::testing::InitGoogleMock();
+	return RUN_ALL_TESTS();
 }

--- a/TradingSystem/main.cpp
+++ b/TradingSystem/main.cpp
@@ -1,256 +1,236 @@
-#include "gmock/gmock.h"
-#include "nemo_api.cpp"
-#include "kiwer_api.cpp"
-#include "mock_driver.cpp"
-#include "stock_broker_driver.h"
-
-#include "nemo_driver.cpp"
-#include "kiwer_driver.cpp"
 #include "auto_trading_system.h"
+#include "gmock/gmock.h"
+#include "kiwer_api.cpp"
+#include "kiwer_driver.cpp"
+#include "mock_driver.cpp"
+#include "nemo_api.cpp"
+#include "nemo_driver.cpp"
+#include "stock_broker_driver.h"
 
 using namespace testing;
 
-class TraingFixture : public Test {
-public:
-	MockStockAPI mockStockAPI;
-	MockDriver mockDriver{ &mockStockAPI };
+class TradingFixture : public Test {
+ public:
+  MockStockAPI mockStockAPI;
 
-	KiwerAPI kiwerAPI;
-	KiwerDriver kiwerDriver{ &kiwerAPI };
+  KiwerDriver kiwerDriver{&kiwerAPI};
+  NemoDriver nemoDriver{&nemoAPI};
+  MockDriver mockDriver{&mockStockAPI};
 
-	NemoAPI nemoAPI;
-	NemoDriver nemoDriver{ &nemoAPI };
+  AutoTradingSystem* autoTradingSystem;
+  StockBrokerDriver* stockBrokerDriver;
 
-	std::string ID = "1234";
-	std::string SUCCESS_PASSWORD = "1234";
-	std::string STOCK_CODE = "code";
+  std::string ID = "1234";
+  std::string SUCCESS_PASSWORD = "1234";
+  std::string STOCK_CODE = "code";
+  int money = 100;
 
-	AutoTradingSystem* autoTradingSystem;
-	int money = 100;
-
-	StockBrokerDriver* stockBrokerDriver;
-private:
-	void SetUp() override {
-		// nothing;
-	}
+ private:
+  KiwerAPI kiwerAPI;
+  NemoAPI nemoAPI;
+  void SetUp() override {
+    // nothing;
+  }
 };
-
 
 ///////////////////////////////////////////
 // Mock test
 //////////////////////////////////////////
-TEST_F(TraingFixture, TEST_LOGIN)
-{
-	stockBrokerDriver = &mockDriver;
+TEST_F(TradingFixture, TEST_LOGIN) {
+  stockBrokerDriver = &mockDriver;
 
-	EXPECT_CALL(mockStockAPI, login(_, _))
-		.Times(1)
-		.WillOnce(Return(true));
-	
-	stockBrokerDriver->login(ID, SUCCESS_PASSWORD);
+  EXPECT_CALL(mockStockAPI, login(_, _)).Times(1).WillOnce(Return(true));
+
+  stockBrokerDriver->login(ID, SUCCESS_PASSWORD);
 }
 
-TEST_F(TraingFixture, TEST_BUY)
-{
-	stockBrokerDriver = &mockDriver;
+TEST_F(TradingFixture, TEST_BUY) {
+  stockBrokerDriver = &mockDriver;
 
-	int quantity = 10;
-	int price = 100;
+  int quantity = 10;
+  int price = 100;
 
-	EXPECT_CALL(mockStockAPI, buy(STOCK_CODE, quantity, price))
-		.Times(1)
-		.WillOnce(Return(true));
+  EXPECT_CALL(mockStockAPI, buy(STOCK_CODE, quantity, price))
+      .Times(1)
+      .WillOnce(Return(true));
 
-	stockBrokerDriver->buy(STOCK_CODE, quantity, price);
+  stockBrokerDriver->buy(STOCK_CODE, quantity, price);
 }
 
-TEST_F(TraingFixture, TEST_SELL)
-{
-	stockBrokerDriver = &mockDriver;
+TEST_F(TradingFixture, TEST_SELL) {
+  stockBrokerDriver = &mockDriver;
 
-	int quantity = 10;
-	int price = 100;
+  int quantity = 10;
+  int price = 100;
 
-	EXPECT_CALL(mockStockAPI, sell(STOCK_CODE, quantity, price))
-		.Times(1)
-		.WillOnce(Return(true));
+  EXPECT_CALL(mockStockAPI, sell(STOCK_CODE, quantity, price))
+      .Times(1)
+      .WillOnce(Return(true));
 
-	stockBrokerDriver->sell(STOCK_CODE, quantity, price);
+  stockBrokerDriver->sell(STOCK_CODE, quantity, price);
 }
 
-TEST_F(TraingFixture, TEST_GET_PRICE)
-{
-	stockBrokerDriver = &mockDriver;
-	int expectedPrice = 100;
+TEST_F(TradingFixture, TEST_GET_PRICE) {
+  stockBrokerDriver = &mockDriver;
+  int expectedPrice = 100;
 
-	EXPECT_CALL(mockStockAPI, getCurrentPrice(STOCK_CODE))
-		.Times(1)
-		.WillOnce(Return(expectedPrice));
+  EXPECT_CALL(mockStockAPI, getCurrentPrice(STOCK_CODE))
+      .Times(1)
+      .WillOnce(Return(expectedPrice));
 
-	int actualPrice = stockBrokerDriver->getCurrentPrice(STOCK_CODE);
+  int actualPrice = stockBrokerDriver->getCurrentPrice(STOCK_CODE);
 
-	EXPECT_EQ(expectedPrice, actualPrice);
+  EXPECT_EQ(expectedPrice, actualPrice);
 }
 
 ///////////////////////////////////////////
 // Auto Trading system test
 //////////////////////////////////////////
-TEST_F(TraingFixture, TEST_buyNiceTiming__Buy_success)
-{
-	// TODO: Change mockDriver to StockBrokerDriver after implemented
-	autoTradingSystem = new AutoTradingSystem(mockDriver); // inherit mock.
-	std::vector<int> price = { 12,20,30 };
+TEST_F(TradingFixture, TEST_buyNiceTiming__Buy_success) {
+  stockBrokerDriver = &mockDriver;
+  autoTradingSystem = new AutoTradingSystem(*stockBrokerDriver);
+  std::vector<int> price = {12, 20, 30};
 
-	EXPECT_CALL(mockStockAPI, getCurrentPrice(STOCK_CODE))
-		.WillOnce(Return(price[0]))
-		.WillOnce(Return(price[1]))
-		.WillOnce(Return(price[2]))
-		.WillRepeatedly(Return(price[2]));
+  EXPECT_CALL(mockStockAPI, getCurrentPrice(STOCK_CODE))
+      .WillOnce(Return(price[0]))
+      .WillOnce(Return(price[1]))
+      .WillOnce(Return(price[2]))
+      .WillRepeatedly(Return(price[2]));
 
-	bool success = autoTradingSystem->buyNiceTiming(STOCK_CODE, money);
-    EXPECT_EQ(true, success);
+  bool success = autoTradingSystem->buyNiceTiming(STOCK_CODE, money);
+  EXPECT_EQ(true, success);
 }
 
-TEST_F(TraingFixture, TEST_buyNiceTiming__Buy_fail)
-{
-	autoTradingSystem = new AutoTradingSystem(mockDriver); // inherit mock.
-	std::vector<int> price = { 40,20,30 };
+TEST_F(TradingFixture, TEST_buyNiceTiming__Buy_fail) {
+  stockBrokerDriver = &mockDriver;
+  autoTradingSystem = new AutoTradingSystem(*stockBrokerDriver);
+  std::vector<int> price = {40, 20, 30};
 
-	EXPECT_CALL(mockStockAPI, getCurrentPrice(STOCK_CODE))
-            .WillOnce(Return(price[0]))
-            .WillOnce(Return(price[1]));
+  EXPECT_CALL(mockStockAPI, getCurrentPrice(STOCK_CODE))
+      .WillOnce(Return(price[0]))
+      .WillOnce(Return(price[1]));
 
-	bool success = autoTradingSystem->buyNiceTiming(STOCK_CODE, money);
-    EXPECT_EQ(false, success);
+  bool success = autoTradingSystem->buyNiceTiming(STOCK_CODE, money);
+  EXPECT_EQ(false, success);
 }
 
-TEST_F(TraingFixture, TEST_sellNiceTiming__Sell_success)
-{
-	autoTradingSystem = new AutoTradingSystem(mockDriver); // inherit mock.
-	std::vector<int> price = { 30,20,12 };
+TEST_F(TradingFixture, TEST_sellNiceTiming__Sell_success) {
+  stockBrokerDriver = &mockDriver;
+  autoTradingSystem = new AutoTradingSystem(*stockBrokerDriver);
+  std::vector<int> price = {30, 20, 12};
 
-	EXPECT_CALL(mockStockAPI, getCurrentPrice(_))
-		.WillOnce(Return(price[0]))
-		.WillOnce(Return(price[1]))
-		.WillOnce(Return(price[2]))
-		.WillRepeatedly(Return(price[2]));
+  EXPECT_CALL(mockStockAPI, getCurrentPrice(_))
+      .WillOnce(Return(price[0]))
+      .WillOnce(Return(price[1]))
+      .WillOnce(Return(price[2]))
+      .WillRepeatedly(Return(price[2]));
 
-	int cellCount = 3;
-	bool success = autoTradingSystem->sellNiceTiming(STOCK_CODE, cellCount);
+  int cellCount = 3;
+  bool success = autoTradingSystem->sellNiceTiming(STOCK_CODE, cellCount);
 
-	EXPECT_EQ(true, success);
+  EXPECT_EQ(true, success);
 }
 
-TEST_F(TraingFixture, TEST_sellNiceTiming__Sell_fail)
-{
-	autoTradingSystem = new AutoTradingSystem(mockDriver); // inherit mock.
-	std::vector<int> price = { 40,20,30 };
+TEST_F(TradingFixture, TEST_sellNiceTiming__Sell_fail) {
+  stockBrokerDriver = &mockDriver;
+  autoTradingSystem = new AutoTradingSystem(*stockBrokerDriver);
+  std::vector<int> price = {40, 20, 30};
 
-	EXPECT_CALL(mockStockAPI, getCurrentPrice(_))
-		.WillOnce(Return(price[0]))
-		.WillOnce(Return(price[1]))
-		.WillOnce(Return(price[2]))
-		.WillRepeatedly(Return(price[2]));
+  EXPECT_CALL(mockStockAPI, getCurrentPrice(_))
+      .WillOnce(Return(price[0]))
+      .WillOnce(Return(price[1]))
+      .WillOnce(Return(price[2]))
+      .WillRepeatedly(Return(price[2]));
 
-	int cellCount = 3;
-	bool success = autoTradingSystem->sellNiceTiming(STOCK_CODE, price[2]);
+  int cellCount = 3;
+  bool success = autoTradingSystem->sellNiceTiming(STOCK_CODE, price[2]);
 
-	EXPECT_EQ(false, success);
+  EXPECT_EQ(false, success);
 }
 
 ///////////////////////////////////////////
 // kiwerAPI test
 //////////////////////////////////////////
-TEST_F(TraingFixture, kiwerAPI_LOGIN)
-{
-	stockBrokerDriver = &kiwerDriver;
-	//EXPECT_CALL(kiwerAPI, login(_, _))
-	//	.Times(1);
+TEST_F(TradingFixture, kiwerAPI_LOGIN) {
+  stockBrokerDriver = &kiwerDriver;
+  // EXPECT_CALL(kiwerAPI, login(_, _))
+  //	.Times(1);
 
-	stockBrokerDriver->login(ID, SUCCESS_PASSWORD);
+  stockBrokerDriver->login(ID, SUCCESS_PASSWORD);
 }
 
-TEST_F(TraingFixture, kiwerAPI_BUY)
-{
-	stockBrokerDriver = &kiwerDriver;
-	int price = 100;
-	int num = 10;
+TEST_F(TradingFixture, kiwerAPI_BUY) {
+  stockBrokerDriver = &kiwerDriver;
+  int price = 100;
+  int num = 10;
 
-	//EXPECT_CALL(kiwerAPI, buy(_, _, _))
-	//	.Times(1);
+  // EXPECT_CALL(kiwerAPI, buy(_, _, _))
+  //	.Times(1);
 
-	stockBrokerDriver->buy(STOCK_CODE, price, num);
+  stockBrokerDriver->buy(STOCK_CODE, price, num);
 }
 
-TEST_F(TraingFixture, kiwerAPI_SELL)
-{
-	stockBrokerDriver = &kiwerDriver;
-	int price = 100;
-	int num = 10;
+TEST_F(TradingFixture, kiwerAPI_SELL) {
+  stockBrokerDriver = &kiwerDriver;
+  int price = 100;
+  int num = 10;
 
-	//EXPECT_CALL(kiwerAPI, sell(_, _, _))
-	//	.Times(1);
+  // EXPECT_CALL(kiwerAPI, sell(_, _, _))
+  //	.Times(1);
 
-	stockBrokerDriver->sell(STOCK_CODE, price, num);
+  stockBrokerDriver->sell(STOCK_CODE, price, num);
 }
 
-TEST_F(TraingFixture, kiwerAPI_GET_PRICE)
-{
-	stockBrokerDriver = &kiwerDriver;
-	int except = 100;
-	int actual = stockBrokerDriver->getCurrentPrice(STOCK_CODE);
+TEST_F(TradingFixture, kiwerAPI_GET_PRICE) {
+  stockBrokerDriver = &kiwerDriver;
+  int except = 100;
+  int actual = stockBrokerDriver->getCurrentPrice(STOCK_CODE);
 
-	//EXPECT_EQ(except, actual);
+  // EXPECT_EQ(except, actual);
 }
-
 
 ///////////////////////////////////////////
 // NemoAPI test
 //////////////////////////////////////////
-TEST_F(TraingFixture, NemoAPI_LOGIN)
-{
-	stockBrokerDriver = &nemoDriver;
-	//EXPECT_CALL(kiwerAPI, login(_, _))
-	//	.Times(1);
+TEST_F(TradingFixture, NemoAPI_LOGIN) {
+  stockBrokerDriver = &nemoDriver;
+  // EXPECT_CALL(kiwerAPI, login(_, _))
+  //	.Times(1);
 
-	stockBrokerDriver->login(ID, SUCCESS_PASSWORD);
+  stockBrokerDriver->login(ID, SUCCESS_PASSWORD);
 }
 
-TEST_F(TraingFixture, NemoAPI_BUY)
-{
-	stockBrokerDriver = &nemoDriver;
-	int price = 100;
-	int num = 10;
+TEST_F(TradingFixture, NemoAPI_BUY) {
+  stockBrokerDriver = &nemoDriver;
+  int price = 100;
+  int num = 10;
 
-	//EXPECT_CALL(kiwerAPI, buy(_, _, _))
-	//	.Times(1);
+  // EXPECT_CALL(kiwerAPI, buy(_, _, _))
+  //	.Times(1);
 
-	stockBrokerDriver->buy(STOCK_CODE, price, num);
+  stockBrokerDriver->buy(STOCK_CODE, price, num);
 }
 
-TEST_F(TraingFixture, NemoAPI_SELL)
-{
-	stockBrokerDriver = &nemoDriver;
-	int price = 100;
-	int num = 10;
+TEST_F(TradingFixture, NemoAPI_SELL) {
+  stockBrokerDriver = &nemoDriver;
+  int price = 100;
+  int num = 10;
 
-	//EXPECT_CALL(kiwerAPI, sell(_, _, _))
-	//	.Times(1);
+  // EXPECT_CALL(kiwerAPI, sell(_, _, _))
+  //	.Times(1);
 
-	stockBrokerDriver->sell(STOCK_CODE, price, num);
+  stockBrokerDriver->sell(STOCK_CODE, price, num);
 }
 
-TEST_F(TraingFixture, NemoAPI_GET_PRICE)
-{
-	stockBrokerDriver = &nemoDriver;
-	int except = 100;
-	int actual = stockBrokerDriver->getCurrentPrice(STOCK_CODE);
+TEST_F(TradingFixture, NemoAPI_GET_PRICE) {
+  stockBrokerDriver = &nemoDriver;
+  int except = 100;
+  int actual = stockBrokerDriver->getCurrentPrice(STOCK_CODE);
 
-	//EXPECT_EQ(except, actual);
+  // EXPECT_EQ(except, actual);
 }
-
 
 int main() {
-	::testing::InitGoogleMock();
-	return RUN_ALL_TESTS();
+  ::testing::InitGoogleMock();
+  return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
이제 AutoTradingSystem도 mockDriver 대신 Interface를 사용합니다.
Coding Style 맞추는 과정에서 다소 많은 line이 변경 처리 되었음에 유의 부탁드립니다.